### PR TITLE
Adding more detail error message in mark tier relations while child boundary was not found

### DIFF
--- a/plugins/macro/textgrid-mark-tier-relations/plugin.json
+++ b/plugins/macro/textgrid-mark-tier-relations/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "textgrid-mark-tier-relations",
-  "version": 3,
+  "version": 4,
   "type": "macro",
   "displayedName": "TextGrid - Mark tier relations",
   "author": "sdercolin",

--- a/plugins/macro/textgrid-mark-tier-relations/textgrid-mark-tier-relations.js
+++ b/plugins/macro/textgrid-mark-tier-relations/textgrid-mark-tier-relations.js
@@ -31,12 +31,20 @@ function alignBoundaries(parents, children) {
             childIndex++
         }
         if (foundChildIndex === null) {
-            error("Could not find child boundary for parent boundary " + parent)
+            return {
+                alignedIndexes: null,
+                parent: parent,
+                childIndex: childIndex
+            }
         } else {
             childBoundaryIndexesAligned.push(foundChildIndex)
         }
     }
-    return childBoundaryIndexesAligned
+    return {
+        alignedIndexes: childBoundaryIndexesAligned,
+        parent: null,
+        childIndex: null
+    }
 }
 
 let wavModulesMap = {}
@@ -75,7 +83,14 @@ for (let module of modules) {
         console.log(`Parent boundaries: ${parentBoundaries}`)
         console.log(`Child boundaries: ${childBoundaries}`)
     }
-    let childBoundaryIndexesAligned = alignBoundaries(parentBoundaries, childBoundaries)
+    let aligned = alignBoundaries(parentBoundaries, childBoundaries)
+    let childBoundaryIndexesAligned = aligned.alignedIndexes
+    if (childBoundaryIndexesAligned == null) {
+        let childName = childEntries[aligned.childIndex-1].name
+        let parentBoundary = aligned.parent
+        let errMsg = `Could not find child boundary for parent boundary ${parentBoundary}`
+        error(`${errMsg}\nHappened in file: ${wavName}\nThe error may occur near entry: ${childName}`)
+    }
     if (debug) {
         console.log(`Child boundary indexes aligned: ${childBoundaryIndexesAligned}`)
     }


### PR DESCRIPTION
Before this change, when user encounter `Could not find child boundary for parent boundary` error, it only show the parent boundary without other information, like the following pitcure shows.
![before](https://github.com/user-attachments/assets/f1a9e08c-4064-48aa-8040-fa36fc8830ba)

After this change, file name and entry name are also added in the error message so that users could located the problem more easily.
![after](https://github.com/user-attachments/assets/a09f9871-ba26-421e-911b-78f626987661)

To implement this change I change the return value of `alignBoundaries` into an object with extra values beside the original array. And move the `error` outside the function. I am not very familar with JavaScript so if there is a more appropriate implementation please let me know and I wound try to improve it.

For testing I only tried messing around with the first and the last boundares, both from child tier and parent tier, it seems working fine and no out of index error is happended.